### PR TITLE
update build-and-publish.yml

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.generate_token.outputs.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker image
         id: meta


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Switch Docker registry login in the build-and-publish workflow to authenticate with secrets.GITHUB_TOKEN instead of a generated token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker authentication in the CI/CD pipeline to use repository-scoped credentials for improved reliability and streamlined deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->