### PR TITLE
first version

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -120,7 +120,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ steps.generate_token.outputs.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for Docker image
         id: meta


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Switch Docker login in the build-and-publish GitHub Actions workflow to authenticate using the built-in GITHUB_TOKEN secret instead of a generated token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker registry authentication in the build and publish workflow to use the built-in GitHub token for improved credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->