### PR TITLE
feat(response-rules): FieldScope + CustomField instead of single Condition Field

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -172,15 +172,19 @@ Rules let a single mock endpoint return different responses based on the incomin
 }
 ```
 
-### Condition Fields
+### Condition Fields (FieldScope + CustomField)
 
-| Field Format | Source | Example |
-|---|---|---|
-| `header.HeaderName` | Request header | `header.Authorization`, `header.X-Api-Key` |
-| `query.paramName` | Query string parameter | `query.page`, `query.category` |
-| `body.propertyPath` | JSON body (dot-notation) | `body.amount`, `body.user.address.city` |
-| `method` | HTTP method | Matches against `GET`, `POST`, etc. |
-| `path` | Request path | Matches against the URL path |
+Rules target a value using a logical **condition field**. In the UI this is configured as **Field Scope** (where to look) plus **Custom Field** (path or key within that scope). The API stores a single `conditionField` string derived from both.
+
+| conditionField format | Field Scope | Custom Field | Description |
+|---|---|---|---|
+| `body.propertyPath` | Body | JSON path (dot-notation) | Request body, e.g. `body.amount`, `body.user.name` |
+| `header.HeaderName` | Header | Header name | Request header, e.g. `header.Authorization`, `header.X-Api-Key` |
+| `query.paramName` | Query parameter | Query key | Query string, e.g. `query.page`, `query.filter` |
+| `route.paramName` | Route parameter | Route param name | From mock route template (e.g. `/api/users/{id}` → `route.id`) |
+| `method` | Method | (none) | HTTP method: `GET`, `POST`, etc. |
+| `path` | Path | (none) | Full request path |
+| `cookie.name` | Cookie | Cookie name | Request cookie, e.g. `cookie.sessionId` |
 
 ### Condition Operators
 

--- a/src/Mocklab.App/Controllers/CatchAllController.cs
+++ b/src/Mocklab.App/Controllers/CatchAllController.cs
@@ -117,7 +117,7 @@ public class CatchAllController(
             // Step 2: Check for matching rules (only if NOT sequential)
             else if (mockResponse.Rules.Count > 0)
             {
-                var matchedRule = _ruleEvaluator.Evaluate(mockResponse.Rules, Request, requestBody);
+                var matchedRule = _ruleEvaluator.Evaluate(mockResponse.Rules, Request, requestBody, mockResponse.Route, requestPath);
                 if (matchedRule != null)
                 {
                     _logger.LogInformation(

--- a/src/Mocklab.App/Services/IRuleEvaluator.cs
+++ b/src/Mocklab.App/Services/IRuleEvaluator.cs
@@ -14,6 +14,8 @@ public interface IRuleEvaluator
     /// <param name="rules">The rules to evaluate, ordered by priority</param>
     /// <param name="request">The incoming HTTP request</param>
     /// <param name="requestBody">The request body (already read)</param>
+    /// <param name="matchedRouteTemplate">The mock's route template (e.g. /api/users/{id}) for route.* rule resolution</param>
+    /// <param name="requestPath">The request path (after prefix) for route parameter extraction</param>
     /// <returns>The matching rule, or null if no rule matches</returns>
-    MockResponseRule? Evaluate(IEnumerable<MockResponseRule> rules, HttpRequest request, string? requestBody);
+    MockResponseRule? Evaluate(IEnumerable<MockResponseRule> rules, HttpRequest request, string? requestBody, string? matchedRouteTemplate = null, string? requestPath = null);
 }


### PR DESCRIPTION
Closes #7

## Summary
- **Backend:** RuleEvaluator supports `route.*` and `cookie.*`; `Evaluate()` takes `matchedRouteTemplate` and `requestPath` for route parameter extraction. `ExtractRouteParameters()` parses route templates (e.g. `/api/users/{id}`) and extracts param values from the request path.
- **CatchAllController:** Passes `mockResponse.Route` and `requestPath` to `RuleEvaluator.Evaluate`.
- **Frontend:** Response Rules form uses **Field Scope** dropdown (Body, Header, Query parameter, Route parameter, Method, Path, Cookie) + **Custom Field** free-text input. `parseConditionField` / `buildConditionField` handle load/save; API still uses single `conditionField` string.
- **Docs:** api-reference.md updated for FieldScope + CustomField and route/cookie.

## Acceptance criteria (from issue)
- [x] Response Rules form shows FieldScope dropdown with: Body, Header, Query parameter, Route parameter, Method, Cookie (and Path).
- [x] CustomField is free-text; placeholder reflects chosen FieldScope.
- [x] Saving rule with e.g. FieldScope=Body, CustomField=`data.name` persists and evaluates correctly.
- [x] Backend supports Route parameter and Cookie in rule evaluation.
- [x] Existing rules (single ConditionField) still evaluate and display in FieldScope + CustomField.
- [x] API continues to accept/store `conditionField` (derived from FieldScope + CustomField on save).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Introduce field scope–based condition configuration in response rules and extend backend evaluation to support route and cookie-based matching.

New Features:
- Add Field Scope and Custom Field inputs to the response rules UI while continuing to persist a single conditionField string to the API.
- Support rule evaluation against route parameters and cookies in the backend rule evaluator.

Enhancements:
- Derive and populate UI rule fields from existing conditionField values when loading mocks, and rebuild conditionField before saving.
- Document the FieldScope + CustomField model and the extended conditionField formats, including route and cookie sources.

Documentation:
- Update API reference to describe FieldScope + CustomField and the expanded set of conditionField formats, including route parameters and cookies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for route parameters and cookies in rule condition fields.
  * Improved rule editor UI with separate Field Scope and Custom Field inputs featuring contextual guidance.

* **Documentation**
  * Updated API reference to document new condition field formats including route and cookie parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->