### PR TITLE
Data Bucket management panel and import (raw JSON + file) (#10)

### DIFF
--- a/src/Mocklab.App/frontend/src/App.jsx
+++ b/src/Mocklab.App/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import Layout from './components/Layout';
 import MockManagementPage from './pages/MockManagementPage';
 import RequestLogsPage from './pages/RequestLogsPage';
 import CollectionsPage from './pages/CollectionsPage';
+import DataBucketsPage from './pages/DataBucketsPage';
 
 // PrimeReact styles
 import 'primereact/resources/themes/lara-light-indigo/theme.css';
@@ -22,6 +23,7 @@ function App() {
             <Route index element={<MockManagementPage />} />
             <Route path="logs" element={<RequestLogsPage />} />
             <Route path="collections" element={<CollectionsPage />} />
+            <Route path="data-buckets/:collectionId" element={<DataBucketsPage />} />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/Mocklab.App/frontend/src/components/TemplateVariablesModal.jsx
+++ b/src/Mocklab.App/frontend/src/components/TemplateVariablesModal.jsx
@@ -39,9 +39,15 @@ export function TemplateVariablesModal({ visible, onHide }) {
         </div>
 
         <div className="font-semibold mb-1">Data buckets (collection)</div>
-        <div className="surface-ground p-2 mb-3 border-round">
-          <code>{'{{ persons[0].name }}'}</code> or <code>{'{{ random_item("persons").name }}'}</code>
+        <p className="text-color-secondary text-xs mt-0 mb-1">
+          The variable name is the <strong>bucket name</strong> you set for the collection (e.g. &quot;persons&quot;, &quot;products&quot;). Manage buckets under Collections → Data Buckets.
+        </p>
+        <div className="surface-ground p-2 mb-1 border-round">
+          <code>{'{{ bucketName[0].field }}'}</code> or <code>{'{{ random_item("bucketName").field }}'}</code>
         </div>
+        <p className="text-color-secondary text-xs mt-0 mb-3">
+          For an <strong>array</strong> bucket, use index or <code>random_item("bucketName")</code>. For a <strong>single object</strong> bucket, <code>random_item("bucketName")</code> returns that object.
+        </p>
 
         <div className="font-semibold mb-1">Example (headers, request, helpers, loop)</div>
         <pre className="surface-ground p-2 border-round overflow-auto text-xs m-0" style={{ maxHeight: '14rem' }}>

--- a/src/Mocklab.App/frontend/src/config/apiConfig.js
+++ b/src/Mocklab.App/frontend/src/config/apiConfig.js
@@ -6,6 +6,8 @@ export const apiConfig = {
   adminLogsPath: '/_admin/logs',
   adminCollectionsPath: '/_admin/collections',
   adminFoldersPath: '/_admin/folders',
+  /** Base path for data-buckets API: use dataBucketsPath(collectionId) for list/create, append /:id for get/update/delete/export */
+  dataBucketsPath: (collectionId) => `/_admin/collections/${collectionId}/data-buckets`,
   timeout: 30000,
 };
 

--- a/src/Mocklab.App/frontend/src/pages/CollectionsPage.jsx
+++ b/src/Mocklab.App/frontend/src/pages/CollectionsPage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
 import { Button } from 'primereact/button';
@@ -18,6 +19,7 @@ import { collectionService } from '../services/collectionService';
 import { mockService } from '../services/mockService';
 
 export default function CollectionsPage() {
+  const navigate = useNavigate();
   const [collections, setCollections] = useState([]);
   const [loading, setLoading] = useState(false);
   const [collectionDialog, setCollectionDialog] = useState(false);
@@ -234,6 +236,7 @@ export default function CollectionsPage() {
 
   const actionBodyTemplate = (rowData) => (
     <div className="flex gap-2">
+      <Button icon="pi pi-database" rounded outlined className="p-button-sm" onClick={() => navigate(`/data-buckets/${rowData.id}`)} tooltip="Data Buckets" tooltipOptions={{ position: 'top' }} />
       <Button icon="pi pi-download" rounded outlined severity="info" className="p-button-sm" onClick={() => exportCollection(rowData)} tooltip="Export" tooltipOptions={{ position: 'top' }} />
       <Button icon="pi pi-pencil" rounded outlined className="p-button-sm" onClick={() => editCollection(rowData)} tooltip="Edit" tooltipOptions={{ position: 'top' }} />
       <Button icon="pi pi-trash" rounded outlined severity="danger" className="p-button-sm" onClick={() => openDeleteCollectionDialog(rowData)} tooltip="Delete" tooltipOptions={{ position: 'top' }} />
@@ -310,7 +313,7 @@ export default function CollectionsPage() {
           <Column field="description" header="Description" body={(rowData) => rowData.description || <span className="text-color-secondary">-</span>} style={{ minWidth: '14rem' }} />
           <Column field="mockCount" header="Mocks" sortable body={(rowData) => <Tag value={rowData.mockCount} severity={rowData.mockCount > 0 ? 'info' : 'secondary'} />} style={{ width: '7rem' }} />
           <Column field="createdAt" header="Created" sortable body={(rowData) => new Date(rowData.createdAt).toLocaleDateString('tr-TR')} style={{ width: '8rem' }} />
-          <Column body={actionBodyTemplate} exportable={false} style={{ width: '10rem' }} />
+          <Column body={actionBodyTemplate} exportable={false} style={{ width: '12rem' }} />
         </DataTable>
       </div>
 

--- a/src/Mocklab.App/frontend/src/pages/DataBucketsPage.jsx
+++ b/src/Mocklab.App/frontend/src/pages/DataBucketsPage.jsx
@@ -1,0 +1,567 @@
+import { useState, useEffect, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { DataTable } from 'primereact/datatable';
+import { Column } from 'primereact/column';
+import { Button } from 'primereact/button';
+import { Dialog } from 'primereact/dialog';
+import { InputText } from 'primereact/inputtext';
+import { InputTextarea } from 'primereact/inputtextarea';
+import { Toast } from 'primereact/toast';
+import { Toolbar } from 'primereact/toolbar';
+import { FileUpload } from 'primereact/fileupload';
+import { collectionService } from '../services/collectionService';
+import { dataBucketService } from '../services/dataBucketService';
+
+const MAX_IMPORT_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+function validateDataJson(str) {
+  if (!str || !str.trim()) return { valid: true, value: '[]' };
+  try {
+    const parsed = JSON.parse(str);
+    if (Array.isArray(parsed) || (typeof parsed === 'object' && parsed !== null)) {
+      return { valid: true, value: JSON.stringify(parsed) };
+    }
+    return { valid: false, error: 'Data must be a JSON array or object.' };
+  } catch (e) {
+    return { valid: false, error: e.message || 'Invalid JSON' };
+  }
+}
+
+export default function DataBucketsPage() {
+  const { collectionId } = useParams();
+  const navigate = useNavigate();
+  const toast = useRef(null);
+  const [buckets, setBuckets] = useState([]);
+  const [collectionName, setCollectionName] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [bucketDialog, setBucketDialog] = useState(false);
+  const [bucket, setBucket] = useState(null);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [saveLoading, setSaveLoading] = useState(false);
+  const [deleteDialog, setDeleteDialog] = useState(false);
+  const [bucketToDelete, setBucketToDelete] = useState(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [importJson, setImportJson] = useState('');
+  const [dataJsonError, setDataJsonError] = useState('');
+
+  const emptyBucket = { name: '', description: '', data: '[]' };
+
+  useEffect(() => {
+    if (!collectionId) return;
+    loadCollection();
+    loadBuckets();
+  }, [collectionId]);
+
+  const loadCollection = async () => {
+    try {
+      const col = await collectionService.getCollection(collectionId);
+      setCollectionName(col?.name ?? 'Collection');
+    } catch {
+      setCollectionName('Collection');
+    }
+  };
+
+  const loadBuckets = async () => {
+    setLoading(true);
+    try {
+      const data = await dataBucketService.getAll(collectionId);
+      setBuckets(data);
+    } catch (error) {
+      toast.current.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to load data buckets: ' + error.message,
+        life: 4000,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const openNew = () => {
+    setBucket(emptyBucket);
+    setIsEditMode(false);
+    setImportJson('');
+    setDataJsonError('');
+    setBucketDialog(true);
+  };
+
+  const editBucket = async (row) => {
+    setBucket({ ...row, data: '[]' });
+    setIsEditMode(true);
+    setImportJson('');
+    setDataJsonError('');
+    setBucketDialog(true);
+    try {
+      const full = await dataBucketService.getOne(collectionId, row.id);
+      setBucket((prev) => ({ ...prev, data: full.data ?? '[]' }));
+    } catch (error) {
+      toast.current.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to load bucket: ' + error.message,
+        life: 4000,
+      });
+    }
+  };
+
+  const hideBucketDialog = () => {
+    setBucketDialog(false);
+    setBucket(null);
+    setDataJsonError('');
+    setImportJson('');
+  };
+
+  const applyImportJson = () => {
+    if (!importJson.trim()) {
+      toast.current.show({
+        severity: 'warn',
+        summary: 'Warning',
+        detail: 'Paste JSON first',
+        life: 3000,
+      });
+      return;
+    }
+    const result = validateDataJson(importJson);
+    if (result.valid) {
+      setBucket((prev) => ({ ...prev, data: result.value }));
+      setDataJsonError('');
+      setImportJson('');
+      toast.current.show({
+        severity: 'success',
+        summary: 'Applied',
+        detail: 'Data replaced with pasted JSON',
+        life: 3000,
+      });
+    } else {
+      setDataJsonError(result.error);
+      toast.current.show({
+        severity: 'error',
+        summary: 'Invalid JSON',
+        detail: result.error,
+        life: 4000,
+      });
+    }
+  };
+
+  const onImportFile = (e) => {
+    const file = e.files && e.files[0];
+    if (!file) return;
+    if (file.size > MAX_IMPORT_FILE_SIZE_BYTES) {
+      toast.current.show({
+        severity: 'error',
+        summary: 'File too large',
+        detail: `Maximum size is ${MAX_IMPORT_FILE_SIZE_BYTES / 1024 / 1024} MB`,
+        life: 4000,
+      });
+      e.options.clear();
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const text = event.target.result;
+        const result = validateDataJson(text);
+        if (result.valid) {
+          setBucket((prev) => ({ ...prev, data: result.value }));
+          setDataJsonError('');
+          setImportJson('');
+          toast.current.show({
+            severity: 'success',
+            summary: 'File loaded',
+            detail: `"${file.name}" applied.`,
+            life: 3000,
+          });
+        } else {
+          setDataJsonError(result.error);
+          toast.current.show({
+            severity: 'error',
+            summary: 'Invalid JSON',
+            detail: result.error,
+            life: 4000,
+          });
+        }
+      } catch {
+        toast.current.show({
+          severity: 'error',
+          summary: 'Invalid JSON',
+          detail: 'The file does not contain valid JSON.',
+          life: 4000,
+        });
+      }
+    };
+    reader.readAsText(file);
+    e.options.clear();
+  };
+
+  const saveBucket = async () => {
+    if (!bucket.name.trim()) {
+      toast.current.show({
+        severity: 'warn',
+        summary: 'Warning',
+        detail: 'Name is required',
+        life: 3000,
+      });
+      return;
+    }
+    const result = validateDataJson(bucket.data);
+    if (!result.valid) {
+      setDataJsonError(result.error);
+      toast.current.show({
+        severity: 'error',
+        summary: 'Invalid JSON',
+        detail: result.error,
+        life: 4000,
+      });
+      return;
+    }
+    setDataJsonError('');
+    setSaveLoading(true);
+    try {
+      const payload = {
+        name: bucket.name.trim(),
+        description: bucket.description?.trim() || null,
+        data: result.value,
+      };
+      if (isEditMode) {
+        await dataBucketService.update(collectionId, bucket.id, payload);
+        toast.current.show({
+          severity: 'success',
+          summary: 'Success',
+          detail: 'Data bucket updated',
+          life: 3000,
+        });
+      } else {
+        await dataBucketService.create(collectionId, payload);
+        toast.current.show({
+          severity: 'success',
+          summary: 'Success',
+          detail: 'Data bucket created',
+          life: 3000,
+        });
+      }
+      hideBucketDialog();
+      loadBuckets();
+    } catch (error) {
+      toast.current.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: error.message,
+        life: 4000,
+      });
+    } finally {
+      setSaveLoading(false);
+    }
+  };
+
+  const openDeleteDialog = (row) => {
+    setBucketToDelete(row);
+    setDeleteDialog(true);
+  };
+
+  const confirmDelete = async () => {
+    if (!bucketToDelete) return;
+    setDeleteLoading(true);
+    try {
+      await dataBucketService.remove(collectionId, bucketToDelete.id);
+      toast.current.show({
+        severity: 'success',
+        summary: 'Success',
+        detail: 'Data bucket deleted',
+        life: 3000,
+      });
+      setDeleteDialog(false);
+      setBucketToDelete(null);
+      loadBuckets();
+    } catch (error) {
+      toast.current.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: error.message,
+        life: 4000,
+      });
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  const exportBucket = async (row) => {
+    try {
+      const data = await dataBucketService.exportBucket(collectionId, row.id);
+      const json = JSON.stringify(data, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${(row.name || 'bucket').toLowerCase().replace(/\s+/g, '-')}-bucket.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast.current.show({
+        severity: 'success',
+        summary: 'Exported',
+        detail: `"${row.name}" downloaded`,
+        life: 3000,
+      });
+    } catch (error) {
+      toast.current.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to export: ' + error.message,
+        life: 3000,
+      });
+    }
+  };
+
+  const exportAll = async () => {
+    try {
+      const data = await dataBucketService.exportAll(collectionId);
+      const json = JSON.stringify(data, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${(collectionName || 'collection').toLowerCase().replace(/\s+/g, '-')}-data-buckets.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast.current.show({
+        severity: 'success',
+        summary: 'Exported',
+        detail: 'All data buckets downloaded',
+        life: 3000,
+      });
+    } catch (error) {
+      toast.current.show({
+        severity: 'error',
+        summary: 'Error',
+        detail: 'Failed to export: ' + error.message,
+        life: 3000,
+      });
+    }
+  };
+
+  const formatJson = () => {
+    const result = validateDataJson(bucket?.data);
+    if (result.valid) {
+      try {
+        const parsed = JSON.parse(result.value);
+        setBucket((prev) => ({ ...prev, data: JSON.stringify(parsed, null, 2) }));
+        setDataJsonError('');
+      } catch {
+        // no-op
+      }
+    }
+  };
+
+  const actionBodyTemplate = (rowData) => (
+    <div className="flex gap-2">
+      <Button
+        icon="pi pi-pencil"
+        rounded
+        outlined
+        className="p-button-sm"
+        onClick={() => editBucket(rowData)}
+        tooltip="Edit"
+        tooltipOptions={{ position: 'top' }}
+      />
+      <Button
+        icon="pi pi-download"
+        rounded
+        outlined
+        severity="info"
+        className="p-button-sm"
+        onClick={() => exportBucket(rowData)}
+        tooltip="Export"
+        tooltipOptions={{ position: 'top' }}
+      />
+      <Button
+        icon="pi pi-trash"
+        rounded
+        outlined
+        severity="danger"
+        className="p-button-sm"
+        onClick={() => openDeleteDialog(rowData)}
+        tooltip="Delete"
+        tooltipOptions={{ position: 'top' }}
+      />
+    </div>
+  );
+
+  const leftToolbarTemplate = () => (
+    <div className="flex gap-2">
+      <Button label="Back to Collections" icon="pi pi-arrow-left" outlined onClick={() => navigate('/collections')} />
+      <Button label="New Data Bucket" icon="pi pi-plus" severity="success" onClick={openNew} />
+      <Button
+        label="Export all"
+        icon="pi pi-download"
+        outlined
+        severity="info"
+        onClick={exportAll}
+        disabled={buckets.length === 0}
+      />
+    </div>
+  );
+
+  const rightToolbarTemplate = () => (
+    <Button label="Refresh" icon="pi pi-refresh" outlined onClick={loadBuckets} />
+  );
+
+  const bucketDialogFooter = (
+    <>
+      <Button label="Cancel" icon="pi pi-times" outlined onClick={hideBucketDialog} />
+      <Button label="Save" icon="pi pi-check" loading={saveLoading} onClick={saveBucket} />
+    </>
+  );
+
+  if (!collectionId) {
+    return (
+      <div className="p-4">
+        <p>Invalid collection.</p>
+        <Button label="Back to Collections" onClick={() => navigate('/collections')} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Toast ref={toast} />
+      <div className="page-header">
+        <div className="page-header-icon">
+          <i className="pi pi-database"></i>
+        </div>
+        <div className="page-header-text">
+          <h1>Data Buckets</h1>
+          <p>{collectionName ? `Data for collection "${collectionName}"` : 'Manage JSON data used in Scriban templates'}</p>
+        </div>
+      </div>
+
+      <div className="card">
+        <Toolbar className="mb-4" start={leftToolbarTemplate} end={rightToolbarTemplate} />
+        <DataTable
+          value={buckets}
+          dataKey="id"
+          loading={loading}
+          stripedRows
+          rowHover
+          emptyMessage="No data buckets. Add one to use in templates (e.g. persons, products)."
+          size="small"
+          scrollable
+          scrollHeight="flex"
+          tableStyle={{ minWidth: '40rem' }}
+        >
+          <Column field="id" header="ID" sortable style={{ width: '4rem' }} />
+          <Column field="name" header="Name" sortable style={{ minWidth: '10rem' }} />
+          <Column
+            field="description"
+            header="Description"
+            body={(row) => row.description || <span className="text-color-secondary">-</span>}
+            style={{ minWidth: '12rem' }}
+          />
+          <Column
+            field="updatedAt"
+            header="Updated"
+            sortable
+            body={(row) => (row.updatedAt ? new Date(row.updatedAt).toLocaleString() : '-')}
+            style={{ width: '10rem' }}
+          />
+          <Column body={actionBodyTemplate} exportable={false} style={{ width: '10rem' }} />
+        </DataTable>
+      </div>
+
+      <Dialog
+        visible={bucketDialog}
+        header={isEditMode ? 'Edit Data Bucket' : 'New Data Bucket'}
+        modal
+        className="p-fluid"
+        style={{ width: 'min(90vw, 42rem)' }}
+        footer={bucketDialogFooter}
+        onHide={hideBucketDialog}
+      >
+        <div className="field">
+          <label htmlFor="bucket-name">Name (used as template variable)</label>
+          <InputText
+            id="bucket-name"
+            value={bucket?.name ?? ''}
+            onChange={(e) => setBucket((prev) => ({ ...prev, name: e.target.value }))}
+            placeholder="e.g. persons, products"
+            className="w-full"
+          />
+        </div>
+        <div className="field">
+          <label htmlFor="bucket-desc">Description (optional)</label>
+          <InputText
+            id="bucket-desc"
+            value={bucket?.description ?? ''}
+            onChange={(e) => setBucket((prev) => ({ ...prev, description: e.target.value }))}
+            placeholder="Brief description"
+            className="w-full"
+          />
+        </div>
+        <div className="field">
+          <div className="flex align-items-center justify-content-between mb-1">
+            <label htmlFor="bucket-data">Data (JSON array or object)</label>
+            <Button label="Format" icon="pi pi-align-left" text className="p-button-sm" onClick={formatJson} />
+          </div>
+          <InputTextarea
+            id="bucket-data"
+            value={bucket?.data ?? '[]'}
+            onChange={(e) => {
+              setBucket((prev) => ({ ...prev, data: e.target.value }));
+              setDataJsonError('');
+            }}
+            rows={8}
+            className="w-full font-monospace"
+            style={{ fontFamily: 'ui-monospace, monospace' }}
+          />
+          {dataJsonError && <small className="text-red-500 block mt-1">{dataJsonError}</small>}
+        </div>
+        <div className="field">
+          <label>Import from JSON</label>
+          <InputTextarea
+            value={importJson}
+            onChange={(e) => setImportJson(e.target.value)}
+            placeholder="Paste JSON here, then click Apply to replace data"
+            rows={3}
+            className="w-full font-monospace mb-2"
+          />
+          <Button label="Apply (replace data)" icon="pi pi-check" outlined onClick={applyImportJson} />
+        </div>
+        <div className="field">
+          <label>Import from file (.json, max 5 MB)</label>
+          <FileUpload
+            mode="basic"
+            accept=".json,application/json"
+            maxFileSize={MAX_IMPORT_FILE_SIZE_BYTES}
+            chooseLabel="Choose JSON file"
+            chooseOptions={{ className: 'p-button-outlined' }}
+            onSelect={onImportFile}
+          />
+        </div>
+      </Dialog>
+
+      <Dialog
+        visible={deleteDialog}
+        header="Delete Data Bucket"
+        modal
+        style={{ width: '24rem' }}
+        onHide={() => setDeleteDialog(false)}
+        footer={
+          <>
+            <Button label="Cancel" icon="pi pi-times" outlined onClick={() => setDeleteDialog(false)} />
+            <Button label="Delete" icon="pi pi-trash" severity="danger" loading={deleteLoading} onClick={confirmDelete} />
+          </>
+        }
+      >
+        {bucketToDelete && (
+          <p>
+            Delete data bucket <strong>{bucketToDelete.name}</strong>? Templates using this bucket will get empty or
+            null data.
+          </p>
+        )}
+      </Dialog>
+    </div>
+  );
+}

--- a/src/Mocklab.App/frontend/src/services/dataBucketService.js
+++ b/src/Mocklab.App/frontend/src/services/dataBucketService.js
@@ -1,0 +1,116 @@
+import apiConfig, { apiUrl, parseErrorResponse } from '../config/apiConfig';
+
+class DataBucketService {
+  getAll(collectionId) {
+    const path = apiConfig.dataBucketsPath(collectionId);
+    return fetch(apiUrl(path), {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(async (response) => {
+      if (!response.ok) {
+        const msg = await parseErrorResponse(response);
+        throw new Error(msg);
+      }
+      return response.json();
+    });
+  }
+
+  getOne(collectionId, bucketId) {
+    const path = `${apiConfig.dataBucketsPath(collectionId)}/${bucketId}`;
+    return fetch(apiUrl(path), {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(async (response) => {
+      if (!response.ok) {
+        const msg = await parseErrorResponse(response);
+        throw new Error(msg);
+      }
+      return response.json();
+    });
+  }
+
+  create(collectionId, data) {
+    const path = apiConfig.dataBucketsPath(collectionId);
+    return fetch(apiUrl(path), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: data.name,
+        description: data.description ?? null,
+        data: data.data ?? '[]',
+      }),
+    }).then(async (response) => {
+      if (!response.ok) {
+        const msg = await parseErrorResponse(response);
+        throw new Error(msg);
+      }
+      return response.json();
+    });
+  }
+
+  update(collectionId, bucketId, data) {
+    const path = `${apiConfig.dataBucketsPath(collectionId)}/${bucketId}`;
+    return fetch(apiUrl(path), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: data.name,
+        description: data.description ?? null,
+        data: data.data ?? '[]',
+      }),
+    }).then(async (response) => {
+      if (!response.ok) {
+        const msg = await parseErrorResponse(response);
+        throw new Error(msg);
+      }
+      return response.json();
+    });
+  }
+
+  remove(collectionId, bucketId) {
+    const path = `${apiConfig.dataBucketsPath(collectionId)}/${bucketId}`;
+    return fetch(apiUrl(path), {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(async (response) => {
+      if (!response.ok) {
+        const msg = await parseErrorResponse(response);
+        throw new Error(msg);
+      }
+      if (response.status === 204) return null;
+      const ct = response.headers.get('content-type');
+      if (ct && ct.includes('application/json')) return response.json();
+      return null;
+    });
+  }
+
+  exportBucket(collectionId, bucketId) {
+    const path = `${apiConfig.dataBucketsPath(collectionId)}/${bucketId}/export`;
+    return fetch(apiUrl(path), {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(async (response) => {
+      if (!response.ok) {
+        const msg = await parseErrorResponse(response);
+        throw new Error(msg);
+      }
+      return response.json();
+    });
+  }
+
+  exportAll(collectionId) {
+    const path = `${apiConfig.dataBucketsPath(collectionId)}/export`;
+    return fetch(apiUrl(path), {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    }).then(async (response) => {
+      if (!response.ok) {
+        const msg = await parseErrorResponse(response);
+        throw new Error(msg);
+      }
+      return response.json();
+    });
+  }
+}
+
+export const dataBucketService = new DataBucketService();


### PR DESCRIPTION
## Summary
Implements [issue #10](https://github.com/burgan-tech/mocklab/issues/10): Data Bucket management UI, import (raw JSON + file), and standalone export.

## Changes

### Backend
- **DataBucketAdminController**: JSON validation on Create/Update for `Data` (array or object); `GET .../data-buckets/{bucketId}/export` (single bucket), `GET .../data-buckets/export` (all buckets). Collection export unchanged (buckets not included).

### Frontend
- **DataBucketsPage** at `/_admin/data-buckets/:collectionId`: list buckets, create/edit (name, description, JSON data), delete with confirmation, import from raw JSON (paste + Apply) and from file (.json, max 5 MB), export single bucket or all buckets as JSON download.
- **CollectionsPage**: Data Buckets action button (database icon) opens the panel for that collection.
- **dataBucketService** + **apiConfig.dataBucketsPath(collectionId)**.
- **TemplateVariablesModal**: clarified that bucket name is the template variable; array vs single-object usage and `random_item("bucketName")`.

### Routing
- SPA route `data-buckets/:collectionId` (no middleware change; `/_admin/data-buckets` is not under `/_admin/collections` so it serves the SPA).

## Acceptance (issue #10)
- [x] Multiple Data Buckets per collection; management panel in collection context
- [x] List, create, edit, delete (with confirmation)
- [x] JSON editor with validation; invalid JSON rejected
- [x] Import from raw JSON (paste + replace)
- [x] Import from file (.json, size limit); validation and errors
- [x] Bucket names required, unique per collection
- [x] Data Buckets export separately (not in collection export)

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Add a collection-scoped Data Buckets management UI with JSON import/export and enforce JSON validation for bucket data on the backend.

New Features:
- Introduce a Data Buckets page for managing per-collection JSON data buckets, including creation, editing, deletion, and listing.
- Add JSON import for data buckets via raw pasted JSON and JSON files with size limits, plus export of single or all buckets as downloadable JSON.
- Expose a dedicated admin route and navigation entry from Collections to access Data Buckets for each collection.

Bug Fixes:
- Validate bucket data as JSON objects or arrays on create/update to prevent storing invalid JSON payloads.

Enhancements:
- Clarify template variable documentation for data buckets, including usage of bucket names, arrays vs single objects, and random_item helper semantics.
- Extend the collections table actions and layout to include quick access to the Data Buckets panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive data buckets management system with create, edit, delete, and export capabilities.
  * Enabled JSON import from file or paste (max 5 MB) with validation and error messaging.
  * Added Data Buckets navigation button to Collections page.
  * Implemented export functionality for individual and all buckets as JSON files.
  * Added JSON validation with inline error feedback during data entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->