### PR TITLE
feat(seed): add JSON file-based seed mechanism with Docker volume sup…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,9 @@ EXPOSE 5000
 # Set environment variables
 ENV ASPNETCORE_URLS=http://+:5000
 
+# Optional: mount a directory containing *.json collection seed files.
+# Files are imported recursively on startup; already-imported collections are skipped.
+# Override at runtime: docker run -v ./my-seed-data:/app/seed -e Mocklab__SeedDirectory=/app/seed ...
+ENV Mocklab__SeedDirectory=
+
 ENTRYPOINT ["dotnet", "Mocklab.Host.dll"]

--- a/src/Mocklab.Host/Extensions/MockerApplicationExtensions.cs
+++ b/src/Mocklab.Host/Extensions/MockerApplicationExtensions.cs
@@ -1,10 +1,13 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Mocklab.Host.Constants;
 using Mocklab.Host.Data;
 using Mocklab.Host.Models;
+using Mocklab.Host.Services;
 
 namespace Mocklab.Host.Extensions;
 
@@ -55,6 +58,13 @@ public static class MocklabApplicationExtensions
             SeedSampleData(dbContext);
         }
 
+        // Seed from directory if configured
+        if (!string.IsNullOrWhiteSpace(options.SeedDirectory))
+        {
+            SeedFromDirectoryAsync(app.ApplicationServices, options.SeedDirectory)
+                .GetAwaiter().GetResult();
+        }
+
         // Enable frontend UI if configured
         if (options.EnableUI)
         {
@@ -62,6 +72,73 @@ public static class MocklabApplicationExtensions
         }
 
         return app;
+    }
+
+    private static async Task SeedFromDirectoryAsync(IServiceProvider services, string seedDirectory)
+    {
+        var loggerFactory = services.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger(nameof(MocklabApplicationExtensions));
+
+        var resolvedPath = Path.IsPathRooted(seedDirectory)
+            ? seedDirectory
+            : Path.Combine(Directory.GetCurrentDirectory(), seedDirectory);
+
+        if (!Directory.Exists(resolvedPath))
+        {
+            logger.LogWarning("Mocklab seed directory '{Path}' does not exist — skipping file seed.", resolvedPath);
+            return;
+        }
+
+        var files = Directory.EnumerateFiles(resolvedPath, "*.json", SearchOption.AllDirectories)
+            .OrderBy(f => f)
+            .ToList();
+
+        if (files.Count == 0)
+        {
+            logger.LogInformation("Mocklab seed directory '{Path}' contains no *.json files.", resolvedPath);
+            return;
+        }
+
+        logger.LogInformation("Mocklab: found {Count} JSON seed file(s) in '{Path}'.", files.Count, resolvedPath);
+
+        int imported = 0, skipped = 0, failed = 0;
+
+        foreach (var file in files)
+        {
+            try
+            {
+                var json = await File.ReadAllTextAsync(file);
+                using var doc = JsonDocument.Parse(json);
+
+                await using var scope = services.CreateAsyncScope();
+                var importer = scope.ServiceProvider.GetRequiredService<IJsonSeedImporter>();
+                var result = await importer.ImportAsync(doc.RootElement, file);
+
+                if (result.Skipped)
+                {
+                    logger.LogDebug("Mocklab seed: skipped '{File}' — {Reason}.", file, result.SkipReason);
+                    skipped++;
+                }
+                else
+                {
+                    imported++;
+                }
+            }
+            catch (JsonException ex)
+            {
+                logger.LogWarning("Mocklab seed: failed to parse '{File}' — {Message}. Skipping.", file, ex.Message);
+                failed++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning("Mocklab seed: failed to import '{File}' — {Message}. Skipping.", file, ex.Message);
+                failed++;
+            }
+        }
+
+        logger.LogInformation(
+            "Mocklab seed complete — imported: {Imported}, skipped: {Skipped}, failed: {Failed}.",
+            imported, skipped, failed);
     }
 
     /// <summary>

--- a/src/Mocklab.Host/Extensions/MockerOptions.cs
+++ b/src/Mocklab.Host/Extensions/MockerOptions.cs
@@ -70,4 +70,13 @@ public class MocklabOptions
     /// Default: "sqlserver"
     /// </summary>
     public string DatabaseProvider { get; set; } = "sqlserver";
+
+    /// <summary>
+    /// Optional directory path scanned recursively for *.json seed files on startup.
+    /// Each JSON file must follow the collection export format (collection + folders + mocks).
+    /// Leave empty to disable. Supports absolute and relative paths.
+    /// Can be overridden at runtime with the Mocklab__SeedDirectory environment variable.
+    /// Default: "" (disabled)
+    /// </summary>
+    public string SeedDirectory { get; set; } = "";
 }

--- a/src/Mocklab.Host/Extensions/MockerServiceExtensions.cs
+++ b/src/Mocklab.Host/Extensions/MockerServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Mocklab.Host.Data;
@@ -13,18 +14,29 @@ public static class MocklabServiceExtensions
 {
     /// <summary>
     /// Adds Mocklab API services to the dependency injection container.
+    /// Reads options from the "Mocklab" section of <paramref name="configuration"/>.
+    /// An optional <paramref name="configure"/> action can override individual values after binding.
     /// </summary>
     /// <param name="services">The service collection</param>
-    /// <param name="configure">Optional configuration action</param>
+    /// <param name="configuration">Application configuration (used to bind the "Mocklab" section)</param>
+    /// <param name="configure">Optional action to override individual option values after config binding</param>
     /// <returns>The service collection for chaining</returns>
     public static IServiceCollection AddMocklab(
         this IServiceCollection services,
+        IConfiguration configuration,
         Action<MocklabOptions>? configure = null)
     {
-        // Register and configure options
+        // Bind options from "Mocklab" config section, then apply any caller overrides
         var options = new MocklabOptions();
+        configuration.GetSection("Mocklab").Bind(options);
+
+        // Fallback: if ConnectionString not set in "Mocklab" section, try ConnectionStrings
+        if (string.IsNullOrEmpty(options.ConnectionString))
+            options.ConnectionString = configuration.GetConnectionString("DefaultConnection") ?? "Data Source=mocklab.db";
+
         configure?.Invoke(options);
-        
+
+        // Register options so the rest of the app can resolve IOptions<MocklabOptions>
         services.Configure<MocklabOptions>(opts =>
         {
             opts.UseHostDatabase = options.UseHostDatabase;
@@ -36,6 +48,7 @@ public static class MocklabServiceExtensions
             opts.AdminRoutePrefix = options.AdminRoutePrefix;
             opts.EnableUI = options.EnableUI;
             opts.DatabaseProvider = options.DatabaseProvider;
+            opts.SeedDirectory = options.SeedDirectory;
         });
 
         services.Configure<MocklabDbOptions>(opts =>
@@ -85,6 +98,7 @@ public static class MocklabServiceExtensions
         // Register business services
         services.AddHttpClient();
         services.AddScoped<IMockImportService, MockImportService>();
+        services.AddScoped<IJsonSeedImporter, JsonSeedImporter>();
         services.AddSingleton<ITemplateProcessor, ScribanTemplateProcessor>();
         services.AddSingleton<IRuleEvaluator, RuleEvaluator>();
         services.AddSingleton<ISequenceStateManager, SequenceStateManager>();

--- a/src/Mocklab.Host/Mocklab.Host.csproj
+++ b/src/Mocklab.Host/Mocklab.Host.csproj
@@ -76,6 +76,14 @@
   <ItemGroup>
     <EmbeddedResource Include="wwwroot\_mocklab\**\*" />
   </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.Development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <!-- Include ProjectReference DLLs inside the NuGet package -->
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">

--- a/src/Mocklab.Host/Program.cs
+++ b/src/Mocklab.Host/Program.cs
@@ -2,19 +2,8 @@ using Mocklab.Host.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add Mocklab services with configuration from appsettings.json
-builder.Services.AddMocklab(options =>
-{
-    // Bind configuration from appsettings.json "Mocklab" section
-    builder.Configuration.GetSection("Mocklab").Bind(options);
-    
-    // Override connection string if not set in config
-    if (string.IsNullOrEmpty(options.ConnectionString))
-    {
-        options.ConnectionString = builder.Configuration.GetConnectionString("DefaultConnection") 
-                                    ?? "Data Source=mocklab.db";
-    }
-});
+// Add Mocklab services — reads the "Mocklab" appsettings section automatically
+builder.Services.AddMocklab(builder.Configuration);
 
 // Add CORS for frontend development
 builder.Services.AddCors(options =>

--- a/src/Mocklab.Host/Services/IJsonSeedImporter.cs
+++ b/src/Mocklab.Host/Services/IJsonSeedImporter.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+
+namespace Mocklab.Host.Services;
+
+/// <summary>
+/// Imports a single collection JSON document into the database during seed.
+/// </summary>
+public interface IJsonSeedImporter
+{
+    /// <summary>
+    /// Imports a collection from a parsed JSON element.
+    /// If a collection with the same name already exists the import is skipped (idempotent).
+    /// </summary>
+    /// <param name="root">Parsed JSON root element (collection export format).</param>
+    /// <param name="sourceFile">Source file path used for logging only.</param>
+    Task<SeedImportResult> ImportAsync(JsonElement root, string sourceFile);
+}
+
+/// <summary>
+/// Result of a single seed file import attempt.
+/// </summary>
+public record SeedImportResult(bool Skipped, string? SkipReason, int MocksImported);

--- a/src/Mocklab.Host/Services/JsonSeedImporter.cs
+++ b/src/Mocklab.Host/Services/JsonSeedImporter.cs
@@ -1,0 +1,230 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Mocklab.Host.Constants;
+using Mocklab.Host.Data;
+using Mocklab.Host.Models;
+
+namespace Mocklab.Host.Services;
+
+public class JsonSeedImporter(
+    MocklabDbContext dbContext,
+    ILogger<JsonSeedImporter> logger) : IJsonSeedImporter
+{
+    private readonly MocklabDbContext _dbContext = dbContext;
+    private readonly ILogger<JsonSeedImporter> _logger = logger;
+
+    private const string KeyValueOwnerTypeMockResponseRule = "MockResponseRule";
+
+    public async Task<SeedImportResult> ImportAsync(JsonElement root, string sourceFile)
+    {
+        if (!root.TryGetProperty("collection", out var collectionData))
+            return new SeedImportResult(true, "Missing 'collection' property", 0);
+
+        if (!root.TryGetProperty("mocks", out var mocksData))
+            return new SeedImportResult(true, "Missing 'mocks' property", 0);
+
+        var collectionName = collectionData.TryGetProperty("name", out var nameEl)
+            ? nameEl.GetString() ?? "Imported Collection"
+            : "Imported Collection";
+
+        var alreadyExists = await _dbContext.MockCollections
+            .AnyAsync(c => c.Name == collectionName);
+
+        if (alreadyExists)
+        {
+            _logger.LogDebug("Seed: skipping '{File}' — collection '{Name}' already exists.", sourceFile, collectionName);
+            return new SeedImportResult(true, $"Collection '{collectionName}' already exists", 0);
+        }
+
+        var collection = new MockCollection
+        {
+            Name = collectionName,
+            Description = collectionData.TryGetProperty("description", out var desc) ? desc.GetString() : null,
+            Color = collectionData.TryGetProperty("color", out var color) ? color.GetString() : null,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _dbContext.MockCollections.Add(collection);
+        await _dbContext.SaveChangesAsync();
+
+        var newFolderIds = new List<int>();
+        if (root.TryGetProperty("folders", out var foldersData))
+        {
+            foreach (var folderEl in foldersData.EnumerateArray())
+            {
+                var name = folderEl.TryGetProperty("name", out var fn) ? fn.GetString() ?? "Folder" : "Folder";
+                var folderColor = folderEl.TryGetProperty("color", out var fc) ? fc.GetString() : null;
+                int? parentFolderId = null;
+                if (folderEl.TryGetProperty("parentFolderIndex", out var p) && p.ValueKind == JsonValueKind.Number)
+                {
+                    var idx = p.GetInt32();
+                    if (idx >= 0 && idx < newFolderIds.Count)
+                        parentFolderId = newFolderIds[idx];
+                }
+
+                var folder = new MockFolder
+                {
+                    CollectionId = collection.Id,
+                    ParentFolderId = parentFolderId,
+                    Name = name,
+                    Color = folderColor,
+                    CreatedAt = DateTime.UtcNow
+                };
+                _dbContext.MockFolders.Add(folder);
+                await _dbContext.SaveChangesAsync();
+                newFolderIds.Add(folder.Id);
+            }
+        }
+
+        var seenMethodRoute = new HashSet<(string Method, string Route)>();
+        var mocksToAdd = new List<MockResponse>();
+        var rulesPerMock = new List<List<(MockResponseRule Rule, List<ResponseHeaderItem> Headers)>>();
+        var sequencePerMock = new List<List<MockResponseSequenceItem>>();
+
+        foreach (var mockData in mocksData.EnumerateArray())
+        {
+            var httpMethod = (mockData.TryGetProperty("httpMethod", out var hm) ? hm.GetString() ?? HttpConstants.MethodGet : HttpConstants.MethodGet)
+                .Trim().ToUpperInvariant();
+            var route = (mockData.TryGetProperty("route", out var rt) ? rt.GetString() ?? "/" : "/").Trim();
+
+            if (!seenMethodRoute.Add((httpMethod, route)))
+                continue;
+
+            int? folderId = null;
+            if (mockData.TryGetProperty("folderIndex", out var folderIndexEl) && folderIndexEl.ValueKind == JsonValueKind.Number)
+            {
+                var fi = folderIndexEl.GetInt32();
+                if (fi >= 0 && fi < newFolderIds.Count)
+                    folderId = newFolderIds[fi];
+            }
+
+            var mock = new MockResponse
+            {
+                HttpMethod = httpMethod,
+                Route = route,
+                QueryString = mockData.TryGetProperty("queryString", out var qs) ? qs.GetString() : null,
+                RequestBody = mockData.TryGetProperty("requestBody", out var rb) ? rb.GetString() : null,
+                StatusCode = mockData.TryGetProperty("statusCode", out var sc) && sc.ValueKind == JsonValueKind.Number ? sc.GetInt32() : 200,
+                ResponseBody = mockData.TryGetProperty("responseBody", out var respBody) ? respBody.GetString() ?? "{}" : "{}",
+                ContentType = mockData.TryGetProperty("contentType", out var ct) ? ct.GetString() ?? "application/json" : "application/json",
+                Description = mockData.TryGetProperty("description", out var d) ? d.GetString() : null,
+                DelayMs = mockData.TryGetProperty("delayMs", out var delay) && delay.ValueKind == JsonValueKind.Number ? delay.GetInt32() : null,
+                IsActive = !mockData.TryGetProperty("isActive", out var ia) || ia.ValueKind != JsonValueKind.False,
+                IsSequential = mockData.TryGetProperty("isSequential", out var seqFlag) && seqFlag.ValueKind == JsonValueKind.True,
+                CollectionId = collection.Id,
+                FolderId = folderId,
+                CreatedAt = DateTime.UtcNow
+            };
+            mocksToAdd.Add(mock);
+
+            var ruleList = new List<(MockResponseRule Rule, List<ResponseHeaderItem> Headers)>();
+            if (mockData.TryGetProperty("rules", out var rulesEl) && rulesEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var ruleEl in rulesEl.EnumerateArray())
+                {
+                    var headers = new List<ResponseHeaderItem>();
+                    if (ruleEl.TryGetProperty("responseHeaders", out var headersEl) && headersEl.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var he in headersEl.EnumerateArray())
+                        {
+                            var key = he.TryGetProperty("key", out var k) ? k.GetString()?.Trim() : null;
+                            if (string.IsNullOrEmpty(key)) continue;
+                            headers.Add(new ResponseHeaderItem
+                            {
+                                Key = key!,
+                                Value = he.TryGetProperty("value", out var v) ? v.GetString() ?? "" : ""
+                            });
+                        }
+                    }
+
+                    ruleList.Add((new MockResponseRule
+                    {
+                        ConditionField = ruleEl.TryGetProperty("conditionField", out var cf) ? cf.GetString() ?? "" : "",
+                        ConditionOperator = ruleEl.TryGetProperty("conditionOperator", out var co) ? co.GetString() ?? "equals" : "equals",
+                        ConditionValue = ruleEl.TryGetProperty("conditionValue", out var cv) ? cv.GetString() : null,
+                        StatusCode = ruleEl.TryGetProperty("statusCode", out var rsc) && rsc.ValueKind == JsonValueKind.Number ? rsc.GetInt32() : 200,
+                        ResponseBody = ruleEl.TryGetProperty("responseBody", out var ruleRb) ? ruleRb.GetString() ?? "{}" : "{}",
+                        ContentType = ruleEl.TryGetProperty("contentType", out var ruleCt) ? ruleCt.GetString() ?? "application/json" : "application/json",
+                        Priority = ruleEl.TryGetProperty("priority", out var pr) && pr.ValueKind == JsonValueKind.Number ? pr.GetInt32() : 0
+                    }, headers));
+                }
+            }
+            rulesPerMock.Add(ruleList);
+
+            var seqList = new List<MockResponseSequenceItem>();
+            if (mockData.TryGetProperty("sequenceItems", out var seqEl) && seqEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var siEl in seqEl.EnumerateArray())
+                {
+                    seqList.Add(new MockResponseSequenceItem
+                    {
+                        Order = siEl.TryGetProperty("order", out var o) && o.ValueKind == JsonValueKind.Number ? o.GetInt32() : 0,
+                        StatusCode = siEl.TryGetProperty("statusCode", out var siSc) && siSc.ValueKind == JsonValueKind.Number ? siSc.GetInt32() : 200,
+                        ResponseBody = siEl.TryGetProperty("responseBody", out var sb) ? sb.GetString() ?? "{}" : "{}",
+                        ContentType = siEl.TryGetProperty("contentType", out var siCt) ? siCt.GetString() ?? "application/json" : "application/json",
+                        DelayMs = siEl.TryGetProperty("delayMs", out var dm) && dm.ValueKind == JsonValueKind.Number ? dm.GetInt32() : null
+                    });
+                }
+            }
+            sequencePerMock.Add(seqList);
+        }
+
+        _dbContext.MockResponses.AddRange(mocksToAdd);
+        await _dbContext.SaveChangesAsync();
+
+        var allRules = new List<MockResponseRule>();
+        var allRuleHeaders = new List<List<ResponseHeaderItem>>();
+        for (var i = 0; i < mocksToAdd.Count; i++)
+        {
+            foreach (var (rule, headers) in rulesPerMock[i])
+            {
+                rule.MockResponseId = mocksToAdd[i].Id;
+                allRules.Add(rule);
+                allRuleHeaders.Add(headers);
+            }
+        }
+
+        if (allRules.Count > 0)
+        {
+            _dbContext.MockResponseRules.AddRange(allRules);
+            await _dbContext.SaveChangesAsync();
+
+            for (var j = 0; j < allRules.Count; j++)
+            {
+                foreach (var h in allRuleHeaders[j])
+                {
+                    _dbContext.KeyValueEntries.Add(new KeyValueEntry
+                    {
+                        OwnerType = KeyValueOwnerTypeMockResponseRule,
+                        OwnerId = allRules[j].Id,
+                        Key = h.Key,
+                        Value = h.Value
+                    });
+                }
+            }
+            await _dbContext.SaveChangesAsync();
+        }
+
+        var allSeqItems = new List<MockResponseSequenceItem>();
+        for (var i = 0; i < mocksToAdd.Count; i++)
+        {
+            foreach (var si in sequencePerMock[i])
+            {
+                si.MockResponseId = mocksToAdd[i].Id;
+                allSeqItems.Add(si);
+            }
+        }
+
+        if (allSeqItems.Count > 0)
+        {
+            _dbContext.MockResponseSequenceItems.AddRange(allSeqItems);
+            await _dbContext.SaveChangesAsync();
+        }
+
+        _logger.LogInformation(
+            "Seed: imported collection '{Name}' from '{File}' — {Count} mock(s).",
+            collectionName, sourceFile, mocksToAdd.Count);
+
+        return new SeedImportResult(false, null, mocksToAdd.Count);
+    }
+}

--- a/src/Mocklab.Host/appsettings.Development.json
+++ b/src/Mocklab.Host/appsettings.Development.json
@@ -16,6 +16,7 @@
     "AutoMigrate": true,
     "SeedSampleData": true,
     "EnableUI": true,
-    "DatabaseProvider": "sqlite"
+    "DatabaseProvider": "sqlite",
+    "SeedDirectory": "./seed"
   }
 }

--- a/src/Mocklab.Host/appsettings.json
+++ b/src/Mocklab.Host/appsettings.json
@@ -16,6 +16,7 @@
     "AutoMigrate": true,
     "SeedSampleData": true,
     "EnableUI": true,
-    "DatabaseProvider": "sqlite"
+    "DatabaseProvider": "sqlite",
+    "SeedDirectory": "./seed"
   }
 }


### PR DESCRIPTION
…port

Introduce an optional startup seed that recursively scans a configurable directory for *.json collection export files and imports them into the database on application start.

- Add SeedDirectory option to MocklabOptions (default: empty/disabled)
- Add IJsonSeedImporter / JsonSeedImporter service that imports a collection export document idempotently (skips if collection name already exists), including folders, mocks, rules, and sequence items
- Add SeedFromDirectoryAsync to UseMocklab startup pipeline, running after AutoMigrate and SeedSampleData; individual file failures are logged as warnings and do not abort startup
- Refactor AddMocklab to accept IConfiguration and bind the "Mocklab" appsettings section internally; callers no longer need to bind manually
- Update Dockerfile runtime stage with MOCKLAB__SeedDirectory env var and volume mount documentation

Closes #27

## Summary by Sourcery

Add configurable JSON file-based seeding of mock collections on startup and streamline Mocklab options binding from configuration.

New Features:
- Introduce a SeedDirectory option that enables recursive JSON-based seed import at application startup when configured.
- Add a JsonSeedImporter service and interface to import collection export JSON files idempotently into the database.

Enhancements:
- Extend the Mocklab service registration to bind options directly from the "Mocklab" configuration section and register the new JSON seed importer.
- Update default configuration and Docker image to support and document seed directory usage via appsettings and environment variables.

Build:
- Adjust Dockerfile to expose a Mocklab__SeedDirectory environment variable and document volume mounting for seed data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections can now be imported from JSON seed files on application startup. Configure the seed directory path via environment variable or configuration file to enable automatic collection seeding. Already-imported collections are skipped automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->