### PR TITLE
fix(deps): remove PrivateAssets="all" from runtime NuGet references

### DIFF
--- a/src/Mocklab.Host/Mocklab.Host.csproj
+++ b/src/Mocklab.Host/Mocklab.Host.csproj
@@ -50,7 +50,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     <PackageReference Include="Scriban" Version="5.12.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -59,7 +59,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" PrivateAssets="all" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Microsoft.AspNetCore.OpenApi and Swashbuckle.AspNetCore.SwaggerUI were marked with PrivateAssets="all", which excluded their DLLs from the publish output. This caused a FileNotFoundException at startup when running in Docker, where only published assemblies are available.

## Summary by Sourcery

Bug Fixes:
- Ensure Microsoft.AspNetCore.OpenApi and Swashbuckle.AspNetCore.SwaggerUI assemblies are included in publish output to prevent FileNotFoundException at startup in Docker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NuGet package reference configuration to make API documentation packages available to dependent projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->