### PR TITLE
Fix incorrect template-variable syntax in dialog and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What Mocklab is
+
+Lightweight, embeddable API mocking for .NET 10 / ASP.NET Core. It ships two ways from the **same** `Mocklab.Host` project:
+
+- **Standalone app / Docker** — built as an `Exe`, run directly.
+- **NuGet library** — consumers call `builder.Services.AddMocklab(config)` + `app.UseMocklab()`.
+
+The `IsPackaging` MSBuild property toggles between these: when `true`, `OutputType` becomes `Library` and `Program.cs` is excluded from compilation (see `Mocklab.Host.csproj`). Keep `Program.cs` free of logic that library consumers need — all reusable wiring lives in the `Extensions/` folder.
+
+## Commands
+
+```bash
+# Run standalone (SQLite, serves admin UI at http://localhost:5000/_admin/)
+dotnet run --project src/Mocklab.Host
+
+# Build / restore the whole solution
+dotnet build Mocklab.slnx
+dotnet restore Mocklab.slnx
+
+# Frontend (React/Vite) — run from src/Mocklab.Host/frontend
+npm install
+npm run dev      # Vite dev server (proxies to backend; CORS allows :3000 and :5173)
+npm run build    # outputs to wwwroot/_mocklab — embedded into the assembly on dotnet build
+npm run lint     # eslint
+
+# Docker
+docker build -t mocklab:latest .
+docker run -d -p 8080:5000 mocklab:latest
+```
+
+There is **no test project** in this repo. `MocklabApi.http` (root) and per-feature `.http` files are the manual API exercise harness.
+
+## Database migrations (critical — multi-provider)
+
+Each provider has its **own** migrations assembly so column types stay native (`Mocklab.Migrations.Sqlite`, `Mocklab.Migrations.PostgreSql`). A migration generated for one provider must **never** be the only one updated — always regenerate for both:
+
+```bash
+./add-migration.sh <MigrationName>   # generates SQLite AND PostgreSQL migrations
+```
+
+The script selects the provider via the `MOCKLAB_DB_PROVIDER` env var, read by `MocklabDesignTimeDbContextFactory` (`sqlite` default, `postgresql`). SQL Server has no migrations assembly — it relies on runtime model creation. Migrations apply automatically on startup when `AutoMigrate` is true (default); failures are logged as warnings and do **not** crash the app.
+
+## Architecture
+
+### Request flow (the heart of the system)
+`CatchAllController` (`Controllers/CatchAllController.cs`) has a single `{**catchAll}` route bound to every HTTP method. For each request it:
+1. Strips `RoutePrefix`, then ignores `/_admin`, `/openapi`, `/swagger`.
+2. `FindMatchingMockResponse` resolves a `MockResponse` by precedence: **exact route → parametric (`/api/users/{id}`) → substring fallback**, preferring body-matching candidates within each tier.
+3. Chooses the response in priority order: **sequential (`SequenceStateManager`) → conditional rule (`RuleEvaluator`) → default mock body**. Sequential and rules are mutually exclusive (sequential wins).
+4. Applies optional delay, runs the body and rule-header values through `ITemplateProcessor` (Scriban), returns a raw `ContentResult` (never re-serialized — avoids a prior 204 bug), and logs to `RequestLog`.
+
+### Routing model (how the catch-all coexists with the host app)
+- `MocklabControllerFeatureProvider` registers Mocklab's controllers **explicitly by type** rather than assembly-scanning, so dropping the library into a consumer project never triggers `ReflectionTypeLoadException`.
+- `MocklabRoutePrefixConvention` rewrites the catch-all route template to `{prefix}/{**catchAll}` when `RoutePrefix` is set. Without a prefix, the catch-all intercepts **all** non-admin routes — this is why integration docs stress setting `RoutePrefix`.
+
+### Project layout
+| Project | Role |
+|---|---|
+| `Mocklab.Host` | Everything: controllers, services, middleware, DI/middleware extensions, embedded React UI. Built as Exe or Library. |
+| `Mocklab.Data` | `MocklabDbContext` + entity models. Note: its `RootNamespace` is `Mocklab.Host`, so models live in the `Mocklab.Host.Models` namespace despite being in this project. |
+| `Mocklab.Migrations.Sqlite` / `Mocklab.Migrations.PostgreSql` | Provider-specific EF Core migrations only. |
+
+`Mocklab.App/` is **not** in the solution (`Mocklab.slnx`) — treat it as legacy; do not edit it.
+
+### Configuration
+`AddMocklab` binds the `Mocklab` config section to `MocklabOptions` (`Extensions/MockerOptions.cs`), then applies an optional override action. Key options: `UseHostDatabase`, `DatabaseProvider` (`sqlite`/`postgresql`/`sqlserver`), `SchemaName` (table isolation when sharing a host DB), `RoutePrefix`, `EnableUI`, `SeedSampleData`, `SeedDirectory`. Connection-string fallback chain: `Mocklab:ConnectionString` → `ConnectionStrings:DefaultConnection` → `Data Source=mocklab.db`. Env-var overrides use the `Mocklab__` prefix (e.g. `Mocklab__SeedDirectory`).
+
+### Seeding
+Two independent mechanisms in `UseMocklab` (`MocklabApplicationExtensions.cs`):
+- `SeedSampleData` — inserts hardcoded sample mocks, only when the table is empty.
+- `SeedDirectory` — recursively imports `*.json` collection-export files via `IJsonSeedImporter` on startup; already-imported collections are skipped (idempotent). This is the Docker volume seed path (`/app/seed`).
+
+### Frontend UI
+React 19 + PrimeReact + Vite, built into `wwwroot/_mocklab/` and embedded as assembly resources. `MocklabStaticFilesMiddleware` serves them under `/_admin/*` with SPA fallback to `index.html`, while passing `/_admin/{mocks,logs,collections,folders}` API calls through to the admin controllers. `dotnet build` auto-runs the frontend build via the `BuildFrontend` MSBuild target (best-effort, `ContinueOnError`).
+
+### Admin API
+`*AdminController`s under `/_admin/...` are the CRUD + import surface for the data model: `MockResponse` (with `MockResponseRule`, `MockResponseSequenceItem`), `MockCollection`, `MockFolder`, `DataBucket`, `RequestLog`. `MockImportService` + `CurlParser` import from cURL and OpenAPI specs. Response headers for rules are stored generically in `KeyValueEntry` keyed by `(OwnerType, OwnerId)`.
+
+## Conventions
+- Target framework is `net10.0`; SDK pinned via `global.json` (10.0.101, `latestFeature` roll-forward).
+- Health endpoint is `/health` (used by the Docker `HEALTHCHECK` and k8s probes).
+- CI publishes Docker image (GHCR) + NuGet package on push to `release-v*` branches (`.github/workflows/build-and-publish.yml`).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -353,18 +353,18 @@ Response bodies and rule response header values (when a rule matches) are proces
 ### Template contract (what you can use)
 
 - **request:** `request.method`, `request.path`, `request.body` (parsed JSON object when body is valid JSON — supports field navigation like `request.body.accountName`; falls back to raw string for non-JSON bodies), `request.body_raw` (always the raw string body), `request.json` (alias for parsed body; kept for backward compatibility), `request.query`, `request.headers`, `request.cookies`, `request.route`.
-- **headers (top-level):** Case-insensitive header access, e.g. `headers["x-correlation-id"]`, `headers["Authorization"]`. Use when the header might be missing: `headers["x-correlation-id"] | "default"` or null coalescing.
-- **helpers:** `helpers.guid()`, `helpers.rand_int(min, maxInclusive)`, `helpers.alphanum(length)`, `helpers.username()` (e.g. fast_tiger42), `helpers.email(domain?)` (default domain example.com).
+- **headers (top-level):** Case-insensitive header access, e.g. `headers["x-correlation-id"]`, `headers["Authorization"]`.
+- **helpers:** the helpers below are available both as top-level expressions (`guid`, `random_int`, `random_alpha_numeric`, `random_username`, `random_email`) and under the `helpers.*` namespace (`helpers.guid`, `helpers.rand_int min maxInclusive`, `helpers.alphanum length`, `helpers.username`, `helpers.email domain?`).
 
-### Helpers (recommended: `helpers.*`)
+### Helpers (use the top-level form, no parentheses)
 
 | Expression | Description |
 |---|---|
-| `{{ helpers.guid() }}` | Random UUID v4 |
-| `{{ helpers.rand_int(1, 100) }}` | Random integer in [min, maxInclusive] |
-| `{{ helpers.alphanum(12) }}` | Random alphanumeric string (length 12) |
-| `{{ helpers.username() }}` | Random username (e.g. fast_tiger42) |
-| `{{ helpers.email() }}` or `{{ helpers.email("my.domain.com") }}` | Random email |
+| `{{ guid }}` | Random UUID v4 |
+| `{{ random_int 1 100 }}` | Random integer in [min, maxInclusive] |
+| `{{ random_alpha_numeric 12 }}` | Random alphanumeric string (length 12) |
+| `{{ random_username }}` | Random username (e.g. fast_tiger42) |
+| `{{ random_email }}` or `{{ helpers.email "my.domain.com" }}` | Random email (default or custom domain) |
 
 ### String helpers
 
@@ -446,9 +446,9 @@ Ready-made random data for common domain objects — no external dependencies. A
 
 ```json
 {
-  "id": "{{ helpers.guid() }}",
+  "id": "{{ guid }}",
   "username": "{{ random_username }}",
-  "email": "{{ helpers.email() }}",
+  "email": "{{ random_email }}",
   "role": "{{ random_role }}",
   "age": {{ random_age }},
   "birthdate": "{{ random_birthdate }}",
@@ -495,7 +495,7 @@ Ready-made random data for common domain objects — no external dependencies. A
 
 | Expression | Description |
 |---|---|
-| `{{ headers["x-correlation-id"] }}` | Header value (case-insensitive). Use `\| "default"` if missing. |
+| `{{ headers["x-correlation-id"] }}` | Header value (case-insensitive). |
 
 ### Data Buckets
 
@@ -509,17 +509,17 @@ Data bucket API: `GET/POST /_admin/collections/{collectionId}/data-buckets`, `GE
 
 ```json
 {
-  "correlationId": "{{ headers["x-correlation-id"] | helpers.guid() }}",
+  "correlationId": "{{ headers["x-correlation-id"] }}",
   "path": "{{ request.path }}",
   "isPremium": {{ request.query["tier"] == "premium" }},
   "items": [
     {{ for i in 0..2 }}
-      { "id": "{{ helpers.guid() }}", "amount": {{ helpers.rand_int(10, 500) }} }{{ if !for.last }},{{ end }}
+      { "id": "{{ guid }}", "amount": {{ random_int 10 500 }} }{{ if !for.last }},{{ end }}
     {{ end }}
   ],
   "user": {
-    "username": "{{ helpers.username() }}",
-    "email": "{{ helpers.email() }}"
+    "username": "{{ random_username }}",
+    "email": "{{ random_email }}"
   }
 }
 ```
@@ -534,7 +534,7 @@ Data bucket API: `GET/POST /_admin/collections/{collectionId}/data-buckets`, `GE
     "userId": "{{ request.route.id }}",
     "auth": "{{ request.headers["Authorization"] }}"
   },
-  "requestId": "{{ helpers.guid() }}",
+  "requestId": "{{ guid }}",
   "bodyParsed": {{ request.json }}
 }
 ```
@@ -547,7 +547,7 @@ When the request body is valid JSON, `request.body` is automatically parsed and 
 {
   "greeting": "Hello, {{ request.body.accountName }}!",
   "accountType": "{{ upper request.body.accountType }}",
-  "transferId": "{{ helpers.guid() }}",
+  "transferId": "{{ guid }}",
   "currency": "{{ request.body.currency }}",
   "echoAmount": {{ request.body.amount }},
   "rawPayload": "{{ request.body_raw }}"
@@ -556,7 +556,7 @@ When the request body is valid JSON, `request.body` is automatically parsed and 
 
 For nested JSON: `{{ request.body.user.name }}`, `{{ request.body.address.city }}`.
 
-> Multiple occurrences of the same helper in one response produce different values (e.g. two `{{ helpers.guid() }}` yield two different UUIDs).
+> Multiple occurrences of the same helper in one response produce different values (e.g. two `{{ guid }}` yield two different UUIDs).
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -124,7 +124,7 @@ Mocklab uses Scriban syntax. You can use simple expressions or full control-flow
 
 ```json
 {
-  "id": "{{ helpers.guid() }}",
+  "id": "{{ guid }}",
   "status": "{{ random_status }}"
 }
 ```
@@ -133,7 +133,7 @@ Mocklab uses Scriban syntax. You can use simple expressions or full control-flow
 {
   "items": [
     {{ for i in 0..2 }}
-      { "id": "{{ helpers.guid() }}", "amount": {{ helpers.rand_int(10, 500) }} }{{ if !for.last }},{{ end }}
+      { "id": "{{ guid }}", "amount": {{ random_int 10 500 }} }{{ if !for.last }},{{ end }}
     {{ end }}
   ]
 }
@@ -175,7 +175,7 @@ Example:
 
 ```json
 {
-  "requestId": "{{ helpers.guid() }}",
+  "requestId": "{{ guid }}",
   "path": "{{ request.path }}",
   "accountName": "{{ upper request.body.accountName }}",
   "tier": "{{ request.query["tier"] }}",
@@ -185,16 +185,18 @@ Example:
 
 ### Core Helper Methods
 
-For common random and string-generation needs, Mocklab exposes a helper namespace:
+For common random and string-generation needs, Mocklab exposes these helpers. Write them as top-level expressions with no parentheses:
 
 | Helper | Description |
 |---|---|
-| `{{ helpers.guid() }}` | Random UUID |
-| `{{ helpers.rand_int(1, 100) }}` | Random integer within a range |
-| `{{ helpers.alphanum(12) }}` | Random alphanumeric string |
-| `{{ helpers.username() }}` | Generated username such as `fast_tiger42` |
-| `{{ helpers.email() }}` | Generated email using `example.com` |
-| `{{ helpers.email("my.domain.com") }}` | Generated email with custom domain |
+| `{{ guid }}` | Random UUID |
+| `{{ random_int 1 100 }}` | Random integer within a range |
+| `{{ random_alpha_numeric 12 }}` | Random alphanumeric string |
+| `{{ random_username }}` | Generated username such as `fast_tiger42` |
+| `{{ random_email }}` | Generated email using `example.com` |
+| `{{ helpers.email "my.domain.com" }}` | Generated email with custom domain |
+
+> Helpers are also available under the `helpers.*` namespace (e.g. `{{ helpers.guid }}`). Use the top-level form shown above for everyday cases.
 
 Additional top-level utility expressions are also available:
 
@@ -392,7 +394,7 @@ The example below combines request values, helpers, and pre-generated content in
 
 ```json
 {
-  "requestId": "{{ helpers.guid() }}",
+  "requestId": "{{ guid }}",
   "customerId": "{{ request.route.id }}",
   "customerName": "{{ request.body.name }}",
   "accountManager": "{{ random_name }}",
@@ -410,7 +412,7 @@ Rules can use the same template capabilities to produce more contextual response
 {
   "tier": "{{ request.query["tier"] }}",
   "priority": "{{ random_priority }}",
-  "campaignCode": "{{ helpers.alphanum(8) }}",
+  "campaignCode": "{{ random_alpha_numeric 8 }}",
   "message": "Premium flow activated for {{ request.headers["X-Customer-Id"] }}"
 }
 ```

--- a/src/Mocklab.Host/Services/TemplateHelpers.cs
+++ b/src/Mocklab.Host/Services/TemplateHelpers.cs
@@ -3,7 +3,10 @@ using System.Security.Cryptography;
 namespace Mocklab.Host.Services;
 
 /// <summary>
-/// Instance helper methods for Scriban templates, exposed as <c>helpers</c> (e.g. helpers.guid(), helpers.rand_int(1, 100)).
+/// Instance helper methods for Scriban templates, exposed under the <c>helpers</c> namespace.
+/// In templates, write them as top-level expressions with no parentheses, e.g. {{ guid }}, {{ random_int 1 100 }}
+/// (also reachable as {{ helpers.guid }}). Note: a parameterless call form like {{ helpers.email() }} throws at
+/// render time when the method has a required parameter — pass the argument: {{ helpers.email "my.domain.com" }}.
 /// Uses RandomNumberGenerator for randomness. Stateless and safe (no file/network access).
 /// </summary>
 public sealed class TemplateHelpers

--- a/src/Mocklab.Host/frontend/package.json
+++ b/src/Mocklab.Host/frontend/package.json
@@ -26,6 +26,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^9.39.1",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",

--- a/src/Mocklab.Host/frontend/src/components/JsonBodyEditor.jsx
+++ b/src/Mocklab.Host/frontend/src/components/JsonBodyEditor.jsx
@@ -16,7 +16,7 @@ function tryBeautify(str) {
  * JSON body editor with syntax highlighting and Beautify. Used for response/request body (and rule/sequence body).
  * Auto-beautifies valid JSON on first render. Beautify button is small and right-aligned.
  */
-export function JsonBodyEditor({ value = '', onChange, height = 200, placeholder, autoBeautify = true, 'data-testid': dataTestId, toastRef }) {
+export function JsonBodyEditor({ value = '', onChange, height = 200, autoBeautify = true, 'data-testid': dataTestId, toastRef }) {
   const editorRef = useRef(null);
   const autoBeautifyDoneRef = useRef(false);
 

--- a/src/Mocklab.Host/frontend/src/components/Layout.jsx
+++ b/src/Mocklab.Host/frontend/src/components/Layout.jsx
@@ -9,6 +9,7 @@ export default function Layout() {
   const navigate = useNavigate();
   const location = useLocation();
   const [mobileMenuActive, setMobileMenuActive] = useState(false);
+  const [prevPathname, setPrevPathname] = useState(location.pathname);
   const [isMobile, setIsMobile] = useState(window.innerWidth <= 991);
   const [logCount, setLogCount] = useState(null);
   const menuRef = useRef(null);
@@ -36,10 +37,11 @@ export default function Layout() {
     return () => clearInterval(interval);
   }, []);
 
-  // Close mobile menu on route change
-  useEffect(() => {
+  // Close mobile menu on route change (adjust state during render — no effect needed)
+  if (prevPathname !== location.pathname) {
+    setPrevPathname(location.pathname);
     setMobileMenuActive(false);
-  }, [location.pathname]);
+  }
 
   // Close mobile menu on outside click
   useEffect(() => {

--- a/src/Mocklab.Host/frontend/src/components/TemplateVariablesModal.jsx
+++ b/src/Mocklab.Host/frontend/src/components/TemplateVariablesModal.jsx
@@ -85,7 +85,7 @@ export function TemplateVariablesModal({ visible, onHide }) {
                   ['{{ request.cookies.sessionId }}', 'Request cookie'],
                   ['{{ request.route.id }}', 'Route parameter (e.g. /api/users/{id})'],
                   ['{{ headers["x-correlation-id"] }}', 'Top-level header (case-insensitive)'],
-                  ['{{ headers["x-id"] | helpers.guid() }}', 'Header with fallback if missing'],
+                  ['{{ headers["x-id"] | upper }}', 'Pipe a header value into a helper (uppercase)'],
                 ].map(([expr, desc]) => (
                   <tr key={expr} style={{ borderBottom: '1px solid var(--surface-border)' }}>
                     <td className="py-1 pr-3"><code>{expr}</code></td>
@@ -99,12 +99,12 @@ export function TemplateVariablesModal({ visible, onHide }) {
           {/* ── Helpers ── */}
           <TabPanel header="Helpers">
             <HelperTable rows={[
-              ['{{ helpers.guid() }}', 'Random UUID v4'],
-              ['{{ helpers.rand_int(1, 100) }}', 'Random integer in [min, max]'],
-              ['{{ helpers.alphanum(12) }}', 'Random alphanumeric string (length 12)'],
-              ['{{ helpers.username() }}', 'Random username (e.g. swift_eagle42)'],
-              ['{{ helpers.email() }}', 'Random email'],
-              ['{{ helpers.email("my.domain.com") }}', 'Random email with custom domain'],
+              ['{{ guid }}', 'Random UUID v4'],
+              ['{{ random_int 1 100 }}', 'Random integer in [min, max]'],
+              ['{{ random_alpha_numeric 12 }}', 'Random alphanumeric string (length 12)'],
+              ['{{ random_username }}', 'Random username (e.g. swift_eagle42)'],
+              ['{{ random_email }}', 'Random email'],
+              ['{{ helpers.email "my.domain.com" }}', 'Random email with custom domain'],
               ['{{ upper "hello" }}', 'Convert to uppercase → HELLO'],
               ['{{ lower "HELLO" }}', 'Convert to lowercase → hello'],
               ['{{ upper request.body.accountName }}', 'Uppercase a body field'],
@@ -122,7 +122,7 @@ export function TemplateVariablesModal({ visible, onHide }) {
               ['{{ random_string 8 }}', 'Random string of length 8'],
               ['{{ random_alpha_numeric 10 }}', 'Random alphanumeric string of length 10'],
               ['{{ random_number_string 6 }}', 'Random numeric string of length 6'],
-            ]} note="All helpers work both as {{ helpers.xxx() }} and as top-level {{ xxx }}." />
+            ]} note={'Write helpers as top-level expressions with no parentheses, e.g. {{ guid }} or {{ random_int 1 100 }}. The same helpers are also available under the helpers.* namespace (e.g. {{ helpers.guid }}, {{ helpers.email "my.domain.com" }}).'} />
           </TabPanel>
 
           {/* ── Arithmetic ── */}
@@ -188,7 +188,7 @@ export function TemplateVariablesModal({ visible, onHide }) {
           {/* ── Pre-generated ── */}
           <TabPanel header="Pre-generated">
             <p className="text-xs text-color-secondary mt-0 mb-2">
-              Ready-made domain data. Available both as <code>{'{{ random_xxx }}'}</code> and <code>{'{{ helpers.random_xxx() }}'}</code>.
+              Ready-made domain data. Use as a top-level expression <code>{'{{ random_xxx }}'}</code> (also available as <code>{'{{ helpers.random_xxx }}'}</code>).
             </p>
 
             <div className="font-medium text-xs mb-1 mt-2">Location & Identity</div>
@@ -231,7 +231,7 @@ export function TemplateVariablesModal({ visible, onHide }) {
 {`{
   "greeting": "Hello, {{ request.body.accountName }}!",
   "accountType": "{{ upper request.body.accountType }}",
-  "transferId": "{{ helpers.guid() }}",
+  "transferId": "{{ guid }}",
   "currency": "{{ request.body.currency }}",
   "echoAmount": {{ request.body.amount }},
   "rawPayload": "{{ request.body_raw }}"
@@ -241,9 +241,9 @@ export function TemplateVariablesModal({ visible, onHide }) {
             <div className="font-medium text-xs mb-1">Pre-generated — user profile</div>
             <pre className="surface-ground p-2 border-round overflow-auto text-xs mb-3" style={{ maxHeight: '10rem' }}>
 {`{
-  "id": "{{ helpers.guid() }}",
+  "id": "{{ guid }}",
   "username": "{{ random_username }}",
-  "email": "{{ helpers.email() }}",
+  "email": "{{ random_email }}",
   "role": "{{ random_role }}",
   "age": {{ random_age }},
   "department": "{{ random_department }}",
@@ -264,11 +264,11 @@ export function TemplateVariablesModal({ visible, onHide }) {
             <div className="font-medium text-xs mb-1">Loop + conditional</div>
             <pre className="surface-ground p-2 border-round overflow-auto text-xs mb-3" style={{ maxHeight: '10rem' }}>
 {`{
-  "correlationId": "{{ headers["x-correlation-id"] | helpers.guid() }}",
+  "correlationId": "{{ headers["x-correlation-id"] }}",
   "isPremium": {{ request.query["tier"] == "premium" }},
   "items": [
     {{ for i in 0..2 }}
-      { "id": "{{ helpers.guid() }}", "amount": {{ helpers.rand_int(10, 500) }} }{{ if !for.last }},{{ end }}
+      { "id": "{{ guid }}", "amount": {{ random_int 10 500 }} }{{ if !for.last }},{{ end }}
     {{ end }}
   ]
 }`}

--- a/src/Mocklab.Host/frontend/src/pages/CollectionsPage.jsx
+++ b/src/Mocklab.Host/frontend/src/pages/CollectionsPage.jsx
@@ -32,7 +32,6 @@ export default function CollectionsPage() {
   const [globalFilter, setGlobalFilter] = useState('');
   const [deleteCollectionDialog, setDeleteCollectionDialog] = useState(false);
   const [deleteCollectionId, setDeleteCollectionId] = useState(null);
-  const [deleteCollectionName, setDeleteCollectionName] = useState('');
   const [deleteCollectionMockCount, setDeleteCollectionMockCount] = useState(0);
   const [deleteCollectionMockIds, setDeleteCollectionMockIds] = useState([]);
   const [deleteCollectionMoveToCollectionId, setDeleteCollectionMoveToCollectionId] = useState(null);
@@ -131,7 +130,6 @@ export default function CollectionsPage() {
 
   const openDeleteCollectionDialog = async (col) => {
     setDeleteCollectionId(col.id);
-    setDeleteCollectionName(col.name);
     setDeleteCollectionMockCount(col.mockCount ?? 0);
     setDeleteCollectionMoveToCollectionId(null);
     setDeleteCollectionMoveToFolderId(null);

--- a/src/Mocklab.Host/frontend/src/services/requestLogService.js
+++ b/src/Mocklab.Host/frontend/src/services/requestLogService.js
@@ -23,7 +23,7 @@ class RequestLogService {
 
     if (!response.ok) {
       let detail = '';
-      try { detail = await response.text(); } catch {}
+      try { detail = await response.text(); } catch { /* ignore body read failure */ }
       throw new Error(`Server error ${response.status}: ${detail || response.statusText}`);
     }
 


### PR DESCRIPTION
## What & why

The **Template Variables** dialog and the docs advertised helpers in the parenthesized dotted form — `{{ helpers.guid() }}`, `{{ helpers.email() }}`, `{{ helpers.rand_int(1, 100) }}`, etc. These don't work as shown.

**Root cause (verified):** `{{ helpers.email() }}` throws at render time because the `email` delegate has a required parameter and is called with zero args. Since `ScribanTemplateProcessor` catches any render exception and **returns the template unprocessed** (`ScribanTemplateProcessor.cs` ~270–274), a single such token leaves the *entire* response body as literal `{{ … }}` — so every token appears broken. The short names `guid`/`rand_int`/`alphanum`/`username`/`email` also only exist under `helpers.*` (there is no top-level `email`; the real token is `random_email`).

I confirmed the exact behavior with an isolated Scriban 7.1.0 repro before editing.

## Changes

**Template-syntax fix (docs + dialog only — engine untouched):**
- `TemplateVariablesModal.jsx` — Helpers tab rows + note, Pre-generated note, a broken `| helpers.guid()` pipe example, and the Examples code blocks.
- `docs/user-guide.md`, `docs/api-reference.md` — helper tables and all example JSON blocks; also removed inaccurate "null coalescing / `| \"default\"`" fallback claims (Scriban has no such operator).
- `TemplateHelpers.cs` — corrected the misleading XML-doc usage example.

Standardized on the verified-working **top-level, no-parentheses** form: `{{ guid }}`, `{{ random_int 1 100 }}`, `{{ random_email }}`, `{{ random_alpha_numeric 12 }}`, `{{ random_username }}`; custom-domain email via `{{ helpers.email "my.domain.com" }}`.

**Also bundled (frontend lint cleanups):**
- `package.json` — add missing `eslint-plugin-react` dev dependency (the config imported it but it wasn't declared, so `npm run lint` crashed).
- `JsonBodyEditor.jsx` (drop unused `placeholder` prop), `CollectionsPage.jsx` (drop unused state), `requestLogService.js` (annotate empty catch), `Layout.jsx` (close mobile menu via render-time state instead of an effect).
- `CLAUDE.md` — repo guidance file.

## Reviewer notes
- Legacy `{{$randomUUID}}`-style tokens (e.g. README line 32) are intentionally left as-is — they're still auto-converted by `NormalizeLegacySyntax`.
- `{{$...}}` engine behavior is unchanged; this is a documentation/UI correction.

## Verification
- Isolated Scriban repro confirmed which forms render vs. throw.
- `npm run build` passes; UI re-embedded.
- Repo-wide grep: no broken `helpers.<short>()` template syntax remains in user-facing files.

## Summary by Sourcery

Correct template helper syntax in user-facing docs and UI, clarify Scriban helper usage, and clean up several frontend and tooling issues.

Bug Fixes:
- Fix broken template helper examples that previously caused render-time errors and left templates unprocessed.

Enhancements:
- Revise the Template Variables dialog to show correct helper and pre-generated template expressions and clarify top-level vs helpers.* usage.
- Clarify XML documentation for TemplateHelpers to describe supported calling forms and parameter requirements.
- Simplify frontend components by removing unused props/state and adjusting mobile menu closing logic.
- Document repository architecture and workflows for AI-assisted development in a new CLAUDE.md file.

Build:
- Add missing eslint-plugin-react dev dependency so the frontend lint script runs reliably.

Documentation:
- Update API reference and user guide examples to use top-level, no-parentheses helper syntax and remove inaccurate header fallback guidance.

Chores:
- Annotate ignored error handling in requestLogService to satisfy linting without altering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized Scriban template helper syntax in API reference and user guide with new top-level helper style
  * Added comprehensive developer documentation for repository setup and architecture

* **Bug Fixes**
  * Improved request log error messages to include HTTP response body details for better debugging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->